### PR TITLE
Img distortion

### DIFF
--- a/client/stylesheets/style.styl
+++ b/client/stylesheets/style.styl
@@ -142,7 +142,6 @@ ul.navbar-right
   
   img.carousel-img
     width 100%
-    max-height 425px
     margin-bottom 20px
   
   a.btn

--- a/client/templates/includes/carousel.coffee
+++ b/client/templates/includes/carousel.coffee
@@ -12,13 +12,14 @@ Template.carousel.helpers
 
 Template.carousel.rendered = ->
   img = $('.carousel-inner .item img')
-  width = img.width()
-  height = img.height()
-  # Make carousel match screen height and crop to not distort
-  newHeight = $(window).height() - 60
-  newMargin = Math.abs(newHeight - height) / 2 + 38
-  img.css('margin-top', -newMargin + 'px')
-  img.css('margin-bottom', -newMargin + 'px')
-  # Fix caption
-  caption = $('.carousel-title')
-  caption.css('top', parseInt(caption.css('top')) + 76 + 'px')
+  $(img).on 'load', ->
+    width = img.width()
+    height = img.height()
+    # Make carousel match screen height and crop to not distort
+    newHeight = $(window).height() - 60
+    newMargin = Math.abs(newHeight - height) / 2 + 38
+    img.css('margin-top', -newMargin + 'px')
+    img.css('margin-bottom', -newMargin + 'px')
+    # Fix caption
+    caption = $('.carousel-title')
+    caption.css('top', parseInt(caption.css('top')) + 76 + 'px')

--- a/client/templates/includes/carousel.coffee
+++ b/client/templates/includes/carousel.coffee
@@ -11,7 +11,14 @@ Template.carousel.helpers
       article
 
 Template.carousel.rendered = ->
-  # Make carousel match screen height
-  f = height: $(window).height() - 60 + 'px'
-  $('.carousel-inner .item img').css(f)
-  $('.carousel').css(f)
+  img = $('.carousel-inner .item img')
+  width = img.width()
+  height = img.height()
+  # Make carousel match screen height and crop to not distort
+  newHeight = $(window).height() - 60
+  newMargin = Math.abs(newHeight - height) / 2 + 38
+  img.css('margin-top', -newMargin + 'px')
+  img.css('margin-bottom', -newMargin + 'px')
+  # Fix caption
+  caption = $('.carousel-title')
+  caption.css('top', parseInt(caption.css('top')) + 76 + 'px')


### PR DESCRIPTION
fixes #7 

Tested in chrome, safari, firefox.
@christineortiz7 hay un issue casi despreciable pero que igual está, solo en Safari. Cuando cargas la pagina por primera vez al abrir el browser, el carousel no es tan grande como todo el window, pero después funciona hasta cuando le haces refresh.

Primera vez:

![screen shot 2015-07-24 at 2 59 14 pm](https://cloud.githubusercontent.com/assets/3270063/8883446/bc45a5da-3214-11e5-8e91-2404f92e8ce9.png)

Refresh:

![screen shot 2015-07-24 at 2 59 37 pm](https://cloud.githubusercontent.com/assets/3270063/8883451/c2d0e22a-3214-11e5-943c-02e5903a29c3.png)

No te preocupes por las cabezas recortadas, el website esta recortando por igual arriba y abajo, es solo que esta foto en particular tiene un millon de espacio mas arriba y no está editada
